### PR TITLE
feat: add allowed tools to Claude GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,8 +43,6 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # Allow Claude to perform web searches and fetch web pages
+          claude_args: '--allowed-tools WebSearch WebFetch "Bash(git fetch:*)" "Bash(git pull:*)"'
 


### PR DESCRIPTION
## Summary
- Enable `WebSearch`, `WebFetch`, `Bash(git fetch:*)`, and `Bash(git pull:*)` as allowed tools for the Claude Code GitHub Action via `claude_args`
- Allows Claude to perform web searches and fetch/pull from git when working on issues and PRs

## Test plan
- [ ] Trigger Claude in a GitHub issue with `@claude` and verify it can use `WebSearch` and `WebFetch`
- [ ] Verify `git fetch` and `git pull` commands work when requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)