### PR TITLE
feat: add gh api to Claude allowed tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,5 +44,5 @@ jobs:
           # prompt: 'Update the pull request description to include a summary of changes.'
 
           # Allow Claude to perform web searches and fetch web pages
-          claude_args: '--allowed-tools WebSearch WebFetch "Bash(git fetch:*)" "Bash(git pull:*)"'
+          claude_args: '--allowed-tools WebSearch WebFetch "Bash(git fetch:*)" "Bash(git pull:*)" "Bash(gh api:*)"'
 


### PR DESCRIPTION
## Summary
- Add `Bash(gh api:*)` to Claude's allowed tools, enabling it to read files, issues, and PRs from other repos on your GitHub account
- Builds on the existing `WebSearch`, `WebFetch`, `git fetch`, and `git pull` permissions

## Test plan
- [ ] Trigger Claude in a GitHub issue and ask it to read a file from another repo using `gh api`
- [ ] Verify existing allowed tools (WebSearch, WebFetch, git fetch/pull) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)