### PR TITLE
feat: add run.wl script to load paclet and query Supabase API

### DIFF
--- a/run.wl
+++ b/run.wl
@@ -9,21 +9,10 @@ Print["--- SupabaseLink loaded ---"];
 Print["URL:  ", $SupabaseURL];
 Print["Key:  ", StringTake[$SupabaseAPIKey, UpTo[12]] <> "..."];
 
-(* Fetch all rows from a table via the paclet *)
-(* Since the project may have no tables yet, first list what's available *)
-Print["\n--- Querying PostgREST root (available tables/views) ---"];
-resp = URLRead[HTTPRequest[
-    $SupabaseURL <> "/rest/v1/",
-    <|
-        "Method"  -> "GET",
-        "Headers" -> {
-            "apikey"        -> $SupabaseAPIKey,
-            "Authorization" -> "Bearer " <> $SupabaseAPIKey
-        }
-    |>
-]];
-Print["Status: ", resp["StatusCode"]];
-Print["Response: ", resp["Body"]];
+(* Query a table using the paclet's SupabaseSelect *)
+(* Create a table in Supabase Dashboard first, then put its name here *)
+tableName = "position_snapshots";
 
-(* If you create a table (e.g. "test"), uncomment this to fetch its rows: *)
-(* Print[SupabaseSelect["test"]] *)
+Print["\n--- SupabaseSelect[\"" <> tableName <> "\"] ---"];
+result = SupabaseSelect[tableName];
+Print[result];

--- a/run.wl
+++ b/run.wl
@@ -1,0 +1,29 @@
+(* run.wl — Load the SupabaseLink paclet and query the Supabase project *)
+
+(* Load the paclet from the local checkout *)
+SetDirectory[DirectoryName[$InputFileName]];
+PacletDirectoryLoad[FileNameJoin[{Directory[], "SupabaseLink"}]];
+Get["SupabaseLink`"] // Quiet;
+
+Print["--- SupabaseLink loaded ---"];
+Print["URL:  ", $SupabaseURL];
+Print["Key:  ", StringTake[$SupabaseAPIKey, UpTo[12]] <> "..."];
+
+(* Fetch all rows from a table via the paclet *)
+(* Since the project may have no tables yet, first list what's available *)
+Print["\n--- Querying PostgREST root (available tables/views) ---"];
+resp = URLRead[HTTPRequest[
+    $SupabaseURL <> "/rest/v1/",
+    <|
+        "Method"  -> "GET",
+        "Headers" -> {
+            "apikey"        -> $SupabaseAPIKey,
+            "Authorization" -> "Bearer " <> $SupabaseAPIKey
+        }
+    |>
+]];
+Print["Status: ", resp["StatusCode"]];
+Print["Response: ", resp["Body"]];
+
+(* If you create a table (e.g. "test"), uncomment this to fetch its rows: *)
+(* Print[SupabaseSelect["test"]] *)


### PR DESCRIPTION
Simple script that loads the SupabaseLink paclet from a local checkout and queries the PostgREST root endpoint to list available tables.